### PR TITLE
Join to JOIN

### DIFF
--- a/_products/dwellingly.md
+++ b/_products/dwellingly.md
@@ -1,6 +1,6 @@
 ---
 name: Dwelling.ly
-problem: The nonprofit Join is currently working to help transition people out of homelessness. However, their current system for staying in touch with landlords is currently inadequate.
-proposal: Create an app with a robust ticketing system to ensure Join staff can connect with their landlords and clients when an issue arises. This will allow Join to provide support and improve success in transitioning people out of homelessness.
+problem: The nonprofit JOIN helps transition people out of homelessness. However, their system for staying in touch with landlords is currently inadequate.
+proposal: Create an app with a robust ticketing system to ensure JOIN staff can connect with their landlords and clients when an issue arises. This will allow JOIN to provide support and improve success in transitioning people out of homelessness.
 status: Active
 ---


### PR DESCRIPTION
For the upcoming Brigade Congress, I received a request to review presentation slides and noticed a few details on the project description: ![current-description](https://user-images.githubusercontent.com/20653086/137349309-a3dd8fe1-dbf6-4ab3-b5b7-08ef7e2994a2.jpg)

JOIN uses all-caps for their name: https://joinpdx.org/

And rather than repeating the word current, I did a line edit so that current is used once. Then I simplified the action verb in the first line so it's more concise.

# Description
- Resolves *#issue_number*
- *A clear and concise description of what the pull request is about.*

# Type of changes
- [ ] Bug fix
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

# Screenshots (optional)
*Insert screenshots of your work.*